### PR TITLE
Bump versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lcov-util"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["gifnksm <makoto.nksm+github@gmail.com>"]
 description = "Utility commands to operate and analyze LCOV trace file at blazingly fast."
 readme = "README.md"

--- a/lcov/Cargo.toml
+++ b/lcov/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lcov"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["gifnksm <makoto.nksm+github@gmail.com>"]
 description = "LCOV tracefile parser/merger/filter in pure Rust."
 readme = "README.md"


### PR DESCRIPTION
lcov: 0.4.0 -> 0.4.1
lcov-util: 0.1.1 -> 0.1.2