### PR TITLE
Bump versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -162,7 +162,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "lcov"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "cargo-readme 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -173,10 +173,10 @@ dependencies = [
 
 [[package]]
 name = "lcov-util"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "lcov 0.4.2",
+ "lcov 0.5.0",
  "structopt 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lcov-util"
-version = "0.1.3"
+version = "0.1.4"
 authors = ["gifnksm <makoto.nksm+github@gmail.com>"]
 description = "Utility commands to operate and analyze LCOV trace file at blazingly fast."
 readme = "README.md"
@@ -11,7 +11,7 @@ repository = "https://github.com/gifnksm/lcov/"
 edition = "2018"
 
 [dependencies]
-lcov = { version = "0.4", path = "lcov" }
+lcov = { version = "0.5", path = "lcov" }
 failure = "0.1"
 structopt = "0.2"
 

--- a/lcov/Cargo.toml
+++ b/lcov/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lcov"
-version = "0.4.2"
+version = "0.5.0"
 authors = ["gifnksm <makoto.nksm+github@gmail.com>"]
 description = "LCOV tracefile parser/merger/filter in pure Rust."
 readme = "README.md"

--- a/lcov/README.md
+++ b/lcov/README.md
@@ -19,7 +19,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-lcov = "0.4"
+lcov = "0.5"
 ```
 
 ## Performance

--- a/lcov/src/lib.rs
+++ b/lcov/src/lib.rs
@@ -12,7 +12,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! lcov = "0.4"
+//! lcov = "0.5"
 //! ```
 //!
 //! # Performance
@@ -142,7 +142,7 @@
 #![warn(unused_import_braces)]
 #![warn(unused_qualifications)]
 #![warn(unused_results)]
-#![doc(html_root_url = "https://docs.rs/lcov/0.4.2")]
+#![doc(html_root_url = "https://docs.rs/lcov/0.5.0")]
 
 pub use reader::Reader;
 pub use record::{Record, RecordKind};


### PR DESCRIPTION
lcov-util: 0.1.3 -> 0.1.4
lcov: 0.4.2 -> 0.5.0